### PR TITLE
setReadTimeout accepts float param

### DIFF
--- a/stubs/AMQPConnection.php
+++ b/stubs/AMQPConnection.php
@@ -269,7 +269,7 @@ class AMQPConnection
     /**
      * Sets the interval of time to wait for income activity from AMQP broker
      *
-     * @param int $timeout
+     * @param float $timeout
      *
      * @return bool
      */


### PR DESCRIPTION
Ref https://github.com/php-amqp/php-amqp/blob/df1241852b359cf12c346beaa68de202257efdf1/amqp_connection.c#L1014-L1016

a bit offtop - can we mention in the description about time units - "Sets the interval of time (in seconds) ..."?