### PR TITLE
PHP 8 Windows - fix https://github.com/php-amqp/php-amqp/issues/390

### DIFF
--- a/amqp.c
+++ b/amqp.c
@@ -31,7 +31,11 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# include "win32/php_stdint.h"
+# if PHP_VERSION_ID >= 80000
+#  include "main/php_stdint.h"
+# else
+#  include "win32/php_stdint.h"
+# endif
 # include "win32/signal.h"
 #else
 # include <stdint.h>

--- a/amqp_basic_properties.c
+++ b/amqp_basic_properties.c
@@ -36,7 +36,11 @@
 
 #ifdef PHP_WIN32
 # include "win32/unistd.h"
-# include "win32/php_stdint.h"
+# if PHP_VERSION_ID >= 80000
+#  include "main/php_stdint.h"
+# else
+#  include "win32/php_stdint.h"
+# endif
 # include "win32/signal.h"
 #else
 # include <signal.h>

--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -30,7 +30,11 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# include "win32/php_stdint.h"
+# if PHP_VERSION_ID >= 80000
+#  include "main/php_stdint.h"
+# else
+#  include "win32/php_stdint.h"
+# endif
 # include "win32/signal.h"
 #else
 # include <stdint.h>

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -31,7 +31,11 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# include "win32/php_stdint.h"
+# if PHP_VERSION_ID >= 80000
+#  include "main/php_stdint.h"
+# else
+#  include "win32/php_stdint.h"
+# endif
 # include "win32/signal.h"
 #else
 # include <signal.h>

--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -32,7 +32,11 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# include "win32/php_stdint.h"
+# if PHP_VERSION_ID >= 80000
+#  include "main/php_stdint.h"
+# else
+#  include "win32/php_stdint.h"
+# endif
 # include "win32/signal.h"
 #else
 # include <signal.h>

--- a/amqp_envelope.c
+++ b/amqp_envelope.c
@@ -30,7 +30,11 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# include "win32/php_stdint.h"
+# if PHP_VERSION_ID >= 80000
+#  include "main/php_stdint.h"
+# else
+#  include "win32/php_stdint.h"
+# endif
 # include "win32/signal.h"
 #else
 

--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -30,7 +30,11 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# include "win32/php_stdint.h"
+# if PHP_VERSION_ID >= 80000
+#  include "main/php_stdint.h"
+# else
+#  include "win32/php_stdint.h"
+# endif
 # include "win32/signal.h"
 #else
 # include <signal.h>

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -30,7 +30,11 @@
 #include "zend_exceptions.h"
 
 #ifdef PHP_WIN32
-# include "win32/php_stdint.h"
+# if PHP_VERSION_ID >= 80000
+#  include "main/php_stdint.h"
+# else
+#  include "win32/php_stdint.h"
+# endif
 # include "win32/signal.h"
 #else
 # include <signal.h>


### PR DESCRIPTION
This PR fixes https://github.com/php-amqp/php-amqp/issues/390 by replacing `# include "win32/php_stdint.h"` with `# include "main/php_stdint.h"` for all PHP 8+ versions.

See https://github.com/php-amqp/php-amqp/issues/386 as well.

Please review and merge.