### PR TITLE
Fix AMQPEnvelope::getDeliveryTag() return type

### DIFF
--- a/stubs/AMQPEnvelope.php
+++ b/stubs/AMQPEnvelope.php
@@ -39,7 +39,7 @@ class AMQPEnvelope extends AMQPBasicProperties
     /**
      * Get the delivery tag of the message.
      *
-     * @return string The delivery tag of the message.
+     * @return integer The delivery tag of the message.
      */
     public function getDeliveryTag()
     {


### PR DESCRIPTION
The stub for **AMQPEnvelope** defines `getDeliveryTag()` as returning `string` instead of `integer` as can be seen in:

* https://github.com/php-amqp/php-amqp/blob/master/amqp_envelope.c#L77

This PR updates it accordingly.