### PR TITLE
Fix: Deprecated: Creation of dynamic property (8.2)

### DIFF
--- a/tests/bug_62354.phpt
+++ b/tests/bug_62354.phpt
@@ -4,7 +4,9 @@ Constructing AMQPQueue with AMQPConnection segfaults
 <?php if (!extension_loaded("amqp")) print "skip"; ?>
 --FILE--
 <?php
-class Amqptest {};
+class Amqptest {
+	public $conn = NULL;
+};
 $o = new Amqptest();
 $o->conn = new AMQPConnection();
 $funcs = array(


### PR DESCRIPTION
```
TEST 164/175 [tests/bug_62354.phpt]
========DIFF========
001+ Deprecated: Creation of dynamic property Amqptest::$conn is deprecated in /work/GIT/pecl-and-ext/amqp/tests/bug_62354.php on line 4
     getHost => 'localhost'
     getLogin => 'guest'
     getPassword => 'guest'
--
========DONE========
FAIL Constructing AMQPQueue with AMQPConnection segfaults [tests/bug_62354.phpt] 

```