### PR TITLE
Fix deprecation issue in PHP 8.1 for $consumerTag argument to AMQPQueue::consume() method

### DIFF
--- a/stubs/AMQPQueue.php
+++ b/stubs/AMQPQueue.php
@@ -105,7 +105,7 @@ class AMQPQueue
      *                              `basic.consume` request and just run $callback
      *                              if it provided. Calling method with empty $callback
      *                              and AMQP_JUST_CONSUME makes no sense.
-     * @param string   $consumerTag A string describing this consumer. Used
+     * @param string | null $consumerTag     A string describing this consumer. Used
      *                              for canceling subscriptions with cancel().
      *
      * @throws AMQPChannelException    If the channel is not open.
@@ -118,7 +118,7 @@ class AMQPQueue
     public function consume(
         callable $callback = null,
         $flags = AMQP_NOPARAM,
-        $consumerTag = null
+        ?$consumerTag = null
     ) {
     }
 


### PR DESCRIPTION
Fix deprecation issue in PHP 8.1 for $consumerTag argument to AMQPQueue::consume() method

Deprecation occurs because the $consumerTag argument is not defined as nullable but it defaults to NULL when nothing is passed to it.

PHP 8.1 deprecation release notes: https://www.php.net/releases/8.1/en.php#deprecations_and_bc_breaks