### PR TITLE
Replace XtOffsetOf() with offsetof() for PHP 8.6

### DIFF
--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -1536,7 +1536,7 @@ PHP_MINIT_FUNCTION(amqp_channel)
 #if PHP_MAJOR_VERSION >= 7
     memcpy(&amqp_channel_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    amqp_channel_object_handlers.offset = XtOffsetOf(amqp_channel_object, zo);
+    amqp_channel_object_handlers.offset = offsetof(amqp_channel_object, zo);
     amqp_channel_object_handlers.free_obj = amqp_channel_free;
 #endif
 

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -1999,7 +1999,7 @@ PHP_MINIT_FUNCTION(amqp_connection)
 
     memcpy(&amqp_connection_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    amqp_connection_object_handlers.offset = XtOffsetOf(amqp_connection_object, zo);
+    amqp_connection_object_handlers.offset = offsetof(amqp_connection_object, zo);
     amqp_connection_object_handlers.free_obj = amqp_connection_free;
 
     return SUCCESS;

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -305,12 +305,12 @@ struct _amqp_connection_object {
 
 static inline amqp_connection_object *php_amqp_connection_object_fetch(zend_object *obj)
 {
-    return (amqp_connection_object *) ((char *) obj - XtOffsetOf(amqp_connection_object, zo));
+    return (amqp_connection_object *) ((char *) obj - offsetof(amqp_connection_object, zo));
 }
 
 static inline amqp_channel_object *php_amqp_channel_object_fetch(zend_object *obj)
 {
-    return (amqp_channel_object *) ((char *) obj - XtOffsetOf(amqp_channel_object, zo));
+    return (amqp_channel_object *) ((char *) obj - offsetof(amqp_channel_object, zo));
 }
 
 #define PHP_AMQP_GET_CONNECTION(obj) php_amqp_connection_object_fetch(Z_OBJ_P(obj))


### PR DESCRIPTION
PHP 8.6 removed XtOffsetOf(), which was an alias for the standard C offsetof() macro. Replace all usages with offsetof() directly.

Ref: https://github.com/php/php-src/commit/7114314c5a96c362b95663f7e7c9184586721f58