### PR TITLE
Include verify flag in persistent connection hash key

### DIFF
--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -107,8 +107,8 @@ static size_t php_amqp_get_connection_hash(amqp_connection_params *params, char 
     return spprintf(
         hash,
         0,
-        "amqp_conn_res_h:%s_p:%d_v:%s_l:%s_p:%s_f:%d_c:%d_h:%d_cacert:%s_cert:%s_key:%s_sasl_method:%d_connection_name:"
-        "%s",
+        "amqp_conn_res_h:%s_p:%d_v:%s_l:%s_p:%s_f:%d_c:%d_h:%d_cacert:%s_cert:%s_key:%s_verify:%d_sasl_method:%d_"
+        "connection_name:%s",
         params->host,
         params->port,
         params->vhost,
@@ -120,6 +120,7 @@ static size_t php_amqp_get_connection_hash(amqp_connection_params *params, char 
         params->cacert,
         params->cert,
         params->key,
+        params->verify,
         params->sasl_method,
         params->connection_name
     );


### PR DESCRIPTION
Two persistent connections to the same host, credentials and TLS files that differ only in `verify` collide on the `persistent_list` key, so a caller requesting `verify=true` can reuse a `verify=false` socket opened earlier in the same worker. `cacert`/`cert`/`key` are already part of the key; this adds `verify` next to them.

No regression test included: the difference is in internal persistent-resource identity and is not observable from userland.