### PR TITLE
Reject TLS client cert/key without a CA certificate

### DIFF
--- a/amqp_connection_resource.c
+++ b/amqp_connection_resource.c
@@ -496,6 +496,7 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
                 "Socket error: could not create SSL socket.",
                 0
             );
+            connection_resource_destructor(resource, persistent);
 
             return NULL;
         }
@@ -535,10 +536,23 @@ amqp_connection_resource *connection_resource_constructor(amqp_connection_params
         }
 
     } else {
+        if (params->cert || params->key) {
+            zend_throw_exception(
+                amqp_connection_exception_class_entry,
+                "Socket error: a TLS client certificate or key was configured without a CA certificate (cacert); "
+                "refusing to fall back to an unencrypted connection.",
+                0
+            );
+            connection_resource_destructor(resource, persistent);
+
+            return NULL;
+        }
+
         resource->socket = amqp_tcp_socket_new(resource->connection_state);
 
         if (!resource->socket) {
             zend_throw_exception(amqp_connection_exception_class_entry, "Socket error: could not create socket.", 0);
+            connection_resource_destructor(resource, persistent);
 
             return NULL;
         }

--- a/tests/amqpconnection_cert_without_cacert.phpt
+++ b/tests/amqpconnection_cert_without_cacert.phpt
@@ -1,0 +1,24 @@
+--TEST--
+AMQPConnection - TLS client cert/key without cacert is rejected instead of falling back to plaintext
+--EXTENSIONS--
+amqp
+--SKIPIF--
+<?php
+if (!getenv("PHP_AMQP_HOST")) print "skip PHP_AMQP_HOST environment variable is not set";
+?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+$cnn->setHost(getenv('PHP_AMQP_HOST'));
+$cnn->setCert('/nonexistent/client.pem');
+$cnn->setKey('/nonexistent/client.key');
+
+try {
+    $cnn->connect();
+    echo "no exception\n";
+} catch (AMQPConnectionException $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+AMQPConnectionException: Socket error: a TLS client certificate or key was configured without a CA certificate (cacert); refusing to fall back to an unencrypted connection.


### PR DESCRIPTION
Calling `setCert()` / `setKey()` without `setCacert()` silently fell through to a plain TCP socket (`amqp_tcp_socket_new`), so a connection configured with a client certificate ran unencrypted with no error. This throws `AMQPConnectionException` in that case instead of connecting in cleartext.

This also adds the missing `connection_resource_destructor()` call on the two socket-creation failure paths, which returned `NULL` without releasing the `pecalloc`-ed resource and the `amqp_new_connection()` state (the adjacent cacert-failure path already does this).

Note: this is a behavior change. A setup that relied on cert/key being silently ignored without a cacert will now get an exception. If you would rather preserve strict BC, I can downgrade the new case to an `E_WARNING` and keep the plaintext path; let me know which you prefer.