### PR TITLE
Fix crash when the consume callback closes its channel

### DIFF
--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -670,6 +670,17 @@ static PHP_METHOD(amqp_queue_class, consume)
     }
 
     while (1) {
+        /* The consume callback below runs userland code that may close the channel
+         * (clearing connection_resource); bail before dereferencing it again. */
+        if (channel_resource->connection_resource == NULL) {
+            zend_throw_exception(
+                amqp_queue_exception_class_entry,
+                "Channel was disconnected during the consume callback.",
+                0
+            );
+            return;
+        }
+
         /* Initialize the message */
         zval message;
 

--- a/tests/amqpqueue_consume_close_channel_in_callback.phpt
+++ b/tests/amqpqueue_consume_close_channel_in_callback.phpt
@@ -1,0 +1,40 @@
+--TEST--
+AMQPQueue::consume() - closing the channel inside the callback throws instead of crashing
+--EXTENSIONS--
+amqp
+--SKIPIF--
+<?php
+if (!getenv("PHP_AMQP_HOST")) print "skip PHP_AMQP_HOST environment variable is not set";
+?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+$cnn->setHost(getenv('PHP_AMQP_HOST'));
+$cnn->connect();
+
+$channel = new AMQPChannel($cnn);
+
+$queue = new AMQPQueue($channel);
+$queue->setName('consume-close-' . bin2hex(random_bytes(16)));
+$queue->setFlags(AMQP_AUTODELETE);
+$queue->declareQueue();
+
+$exchange = new AMQPExchange($channel);
+$exchange->setType(AMQP_EX_TYPE_DIRECT);
+$exchange->setName('');
+$exchange->publish('payload', $queue->getName());
+
+try {
+    $queue->consume(function (AMQPEnvelope $envelope, AMQPQueue $q) use ($channel) {
+        echo 'received: ', $envelope->getBody(), "\n";
+        $channel->close();
+        return true;
+    });
+    echo "consume returned\n";
+} catch (AMQPQueueException $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+received: payload
+AMQPQueueException: Channel was disconnected during the consume callback.


### PR DESCRIPTION
The `AMQPQueue::consume()` loop caches the channel resource and reuses it after each userland callback. A callback that calls `$channel->close()` clears `connection_resource`, and the next loop iteration dereferenced it (`channel_resource->connection_resource->...`), crashing the process.

This re-checks `connection_resource` at the top of every iteration and throws `AMQPQueueException` instead.

Verified with a live broker: the included test crashes (core dump) on current `latest` and passes with this change.