### PR TITLE
Fix crash serializing integer-keyed argument arrays

### DIFF
--- a/amqp_type.c
+++ b/amqp_type.c
@@ -124,16 +124,23 @@ void php_amqp_type_zval_to_amqp_table_internal(zval *array, amqp_table_t *amqp_t
     zend_ulong index;
     char *key;
     unsigned key_len;
+    uint32_t allocated;
     ht = Z_ARRVAL_P(array);
 
-    amqp_table->entries =
-        (amqp_table_entry_t *) ecalloc((size_t) zend_hash_num_elements(ht), sizeof(amqp_table_entry_t));
+    allocated = zend_hash_num_elements(ht);
+    amqp_table->entries = (amqp_table_entry_t *) ecalloc((size_t) allocated, sizeof(amqp_table_entry_t));
     amqp_table->num_entries = 0;
 
     ZEND_HASH_FOREACH_KEY_VAL(ht, index, zkey, value_nested)
         char *string_key;
         amqp_table_entry_t *table_entry;
         amqp_field_value_t *field;
+
+        /* A nested AMQPValue::toAmqpValue() callback may grow this table while we
+         * iterate it; never write past the buffer sized above. */
+        if ((uint32_t) amqp_table->num_entries >= allocated) {
+            break;
+        }
 
         /* Now pull the key */
         if (!zkey) {
@@ -178,19 +185,37 @@ void php_amqp_type_zval_to_amqp_array_internal(zval *value, amqp_array_t *argume
 
     zval *value_nested;
 
+    zend_ulong index;
     zend_string *zkey;
+    uint32_t allocated;
 
     ht = Z_ARRVAL_P(value);
 
     /* Allocate all the memory necessary for storing the arguments */
-    arguments->entries =
-        (amqp_field_value_t *) ecalloc((size_t) zend_hash_num_elements(ht), sizeof(amqp_field_value_t));
+    allocated = zend_hash_num_elements(ht);
+    arguments->entries = (amqp_field_value_t *) ecalloc((size_t) allocated, sizeof(amqp_field_value_t));
     arguments->num_entries = 0;
 
-    ZEND_HASH_FOREACH_STR_KEY_VAL(ht, zkey, value_nested)
+    ZEND_HASH_FOREACH_KEY_VAL(ht, index, zkey, value_nested)
+        char str[32];
+        char *key;
+
+        /* A nested AMQPValue::toAmqpValue() callback may grow this array while we
+         * iterate it; never write past the buffer sized above. */
+        if ((uint32_t) arguments->num_entries >= allocated) {
+            break;
+        }
+
         amqp_field_value_t *field = &arguments->entries[arguments->num_entries++];
 
-        if (!php_amqp_type_zval_to_amqp_value_internal(value_nested, &field, ZSTR_VAL(zkey), depth)) {
+        if (zkey) {
+            key = ZSTR_VAL(zkey);
+        } else {
+            snprintf(str, sizeof(str), ZEND_ULONG_FMT, index);
+            key = str;
+        }
+
+        if (!php_amqp_type_zval_to_amqp_value_internal(value_nested, &field, key, depth)) {
             /* Reset entries counter back */
             arguments->num_entries--;
 

--- a/tests/amqptype_integer_keyed_unsupported_value.phpt
+++ b/tests/amqptype_integer_keyed_unsupported_value.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Serializing an integer-keyed array with an unsupported value warns instead of crashing
+--EXTENSIONS--
+amqp
+--SKIPIF--
+<?php
+if (!getenv("PHP_AMQP_HOST")) print "skip PHP_AMQP_HOST environment variable is not set";
+?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+$cnn->setHost(getenv('PHP_AMQP_HOST'));
+$cnn->connect();
+
+$channel = new AMQPChannel($cnn);
+
+$queue = new AMQPQueue($channel);
+$queue->setName('args-' . bin2hex(random_bytes(16)));
+$queue->setFlags(AMQP_AUTODELETE);
+$queue->setArguments(['x-nested' => [fopen('php://memory', 'r')]]);
+$queue->declareQueue();
+
+echo "ok\n";
+?>
+--EXPECTF--
+Warning: AMQPQueue::declareQueue(): Ignoring field '0' due to unsupported value type (resource) in %s on line %d
+ok


### PR DESCRIPTION
When `setArguments()` / message headers contain a nested integer-keyed array (a sequential list) holding an unsupported value type, the array branch of the serializer passed `ZSTR_VAL` on a `NULL` `zend_string` (integer keys have no string key) as the field name. The unsupported-type path then read that bogus pointer through its `'%s'` warning and crashed. The key is now built from the integer index, matching the table branch.

While here: both serializer branches sized the entries buffer once with `zend_hash_num_elements()` and wrote one entry per `foreach` iteration, so a nested `AMQPValue::toAmqpValue()` callback that grows the same array under iteration could write past the buffer. The write index is now capped at the allocated count.

Verified with a live broker: the included test crashes (core dump) on current `latest` and passes with this change.