### PR TITLE
Free publish headers table when the channel is unavailable

### DIFF
--- a/amqp_exchange.c
+++ b/amqp_exchange.c
@@ -604,6 +604,9 @@ static PHP_METHOD(amqp_exchange_class, publish)
         }
     }
 
+    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
+    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not publish to exchange.");
+
     amqp_table_t *headers = NULL;
 
     if (ini_arr && (tmp = zend_hash_str_find(HASH_OF(ini_arr), ZEND_STRL("headers"))) != NULL) {
@@ -615,9 +618,6 @@ static PHP_METHOD(amqp_exchange_class, publish)
         props._flags |= AMQP_BASIC_HEADERS_FLAG;
         props.headers = *headers;
     }
-
-    channel_resource = PHP_AMQP_GET_CHANNEL_RESOURCE(PHP_AMQP_READ_THIS_PROP("channel"));
-    PHP_AMQP_VERIFY_CHANNEL_RESOURCE(channel_resource, "Could not publish to exchange.");
 
 #ifndef PHP_WIN32
     /* Start ignoring SIGPIPE */

--- a/tests/amqpexchange_publish_headers_no_leak_on_closed_channel.phpt
+++ b/tests/amqpexchange_publish_headers_no_leak_on_closed_channel.phpt
@@ -1,0 +1,31 @@
+--TEST--
+AMQPExchange::publish() - headers table is not built (nor leaked) when the channel is unavailable
+--EXTENSIONS--
+amqp
+--SKIPIF--
+<?php
+if (!getenv("PHP_AMQP_HOST")) print "skip PHP_AMQP_HOST environment variable is not set";
+?>
+--FILE--
+<?php
+$cnn = new AMQPConnection();
+$cnn->setHost(getenv('PHP_AMQP_HOST'));
+$cnn->connect();
+
+$channel = new AMQPChannel($cnn);
+
+$exchange = new AMQPExchange($channel);
+$exchange->setType(AMQP_EX_TYPE_DIRECT);
+$exchange->setName('');
+
+$cnn->disconnect();
+
+try {
+    $exchange->publish('body', 'rk', AMQP_NOPARAM, ['headers' => ['x-foo' => str_repeat('A', 4096)]]);
+    echo "no exception\n";
+} catch (AMQPChannelException $e) {
+    echo $e::class, ': ', $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+AMQPChannelException: Could not publish to exchange. No channel available.


### PR DESCRIPTION
AMQPExchange::publish() converted the `headers` array into an `amqp_table_t` before the `PHP_AMQP_VERIFY_CHANNEL_RESOURCE` check, so when the channel was closed or disconnected the function threw and returned before reaching `php_amqp_type_free_amqp_table()`, leaking the table and its copied entries. `declareExchange()`, `bind()` and `unbind()` already build their tables after the check; this moves `publish()` to match.

Verified with valgrind: publishing with headers on a disconnected channel leaks the full table on current `latest` (a 1,000,066-byte block with a 1 MB header value) and leaks nothing with this change.