### PR TITLE
Populate clusterId on received messages

### DIFF
--- a/amqp_basic_properties.c
+++ b/amqp_basic_properties.c
@@ -939,5 +939,18 @@ void php_amqp_basic_properties_extract(amqp_basic_properties_t *props, zval *obj
         zend_update_property_null(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("appId"));
     }
 
+    if (props->_flags & AMQP_BASIC_CLUSTER_ID_FLAG) {
+        zend_update_property_stringl(
+            this_ce,
+            PHP_AMQP_COMPAT_OBJ_P(obj),
+            ZEND_STRL("clusterId"),
+            (const char *) props->cluster_id.bytes,
+            (size_t) props->cluster_id.len
+        );
+    } else {
+        /* BC */
+        zend_update_property_null(this_ce, PHP_AMQP_COMPAT_OBJ_P(obj), ZEND_STRL("clusterId"));
+    }
+
     zval_ptr_dtor(&headers);
 }


### PR DESCRIPTION
`php_amqp_basic_properties_extract()` reads every basic property except `cluster_id`, so `AMQPEnvelope::getClusterId()` (and `AMQPBasicProperties::getClusterId()` on a received message) always returns `null`, even when the broker set a cluster id. This extracts it the same way as `appId` / `userId`.

No round-trip test is included because `AMQPExchange::publish()` does not emit `cluster_id`, so this client cannot produce a message carrying one. Happy to add publish-side support in a separate PR if you want it covered end to end.