### PR TITLE
fix build with PHP 8.6.0alpha2

### DIFF
--- a/amqp_channel.c
+++ b/amqp_channel.c
@@ -298,7 +298,7 @@ static PHP_METHOD(amqp_channel_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("prefetchCount"),
-        INI_INT("amqp.prefetch_count")
+        zend_ini_long_literal("amqp.prefetch_count")
     );
 
     /* Set the prefetch size */
@@ -306,7 +306,7 @@ static PHP_METHOD(amqp_channel_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("prefetchSize"),
-        INI_INT("amqp.prefetch_size")
+        zend_ini_long_literal("amqp.prefetch_size")
     );
 
     /* Set the global prefetch count */
@@ -314,7 +314,7 @@ static PHP_METHOD(amqp_channel_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("globalPrefetchCount"),
-        INI_INT("amqp.global_prefetch_count")
+        zend_ini_long_literal("amqp.global_prefetch_count")
     );
 
     /* Set the global prefetch size */
@@ -322,7 +322,7 @@ static PHP_METHOD(amqp_channel_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("globalPrefetchSize"),
-        INI_INT("amqp.global_prefetch_size")
+        zend_ini_long_literal("amqp.global_prefetch_size")
     );
 
     /* Pull out and verify the connection */
@@ -1536,7 +1536,7 @@ PHP_MINIT_FUNCTION(amqp_channel)
 #if PHP_MAJOR_VERSION >= 7
     memcpy(&amqp_channel_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    amqp_channel_object_handlers.offset = XtOffsetOf(amqp_channel_object, zo);
+    amqp_channel_object_handlers.offset = offsetof(amqp_channel_object, zo);
     amqp_channel_object_handlers.free_obj = amqp_channel_free;
 #endif
 

--- a/amqp_connection.c
+++ b/amqp_connection.c
@@ -72,12 +72,12 @@ zend_object_handlers amqp_connection_object_handlers;
     }                                                                                                                  \
     if (zdata && Z_STRLEN_P(zdata) > 0) {                                                                              \
         zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), Z_STRVAL_P(zdata));    \
-    } else if (strlen(INI_STR("amqp." name)) > 0) {                                                                    \
+    } else if (strlen(zend_ini_string_literal("amqp." name)) > 0) {                                                                    \
         zend_update_property_string(                                                                                   \
             this_ce,                                                                                                   \
             PHP_AMQP_COMPAT_OBJ_P(getThis()),                                                                          \
             ZEND_STRL(name),                                                                                           \
-            INI_STR("amqp." name)                                                                                      \
+            zend_ini_string_literal("amqp." name)                                                                                      \
         );                                                                                                             \
     }
 
@@ -90,7 +90,7 @@ zend_object_handlers amqp_connection_object_handlers;
     if (zdata) {                                                                                                       \
         zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), Z_LVAL_P(zdata));        \
     } else {                                                                                                           \
-        zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), INI_INT("amqp." name));  \
+        zend_update_property_bool(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL(name), zend_ini_long_literal("amqp." name));  \
     }
 
 static int php_amqp_connection_resource_deleter(zval *el, amqp_connection_resource *connection_resource)
@@ -388,7 +388,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
             this_ce,
             PHP_AMQP_COMPAT_OBJ_P(getThis()),
             ZEND_STRL("login"),
-            INI_STR("amqp.login")
+            zend_ini_string_literal("amqp.login")
         );
     }
 
@@ -422,7 +422,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
             this_ce,
             PHP_AMQP_COMPAT_OBJ_P(getThis()),
             ZEND_STRL("password"),
-            INI_STR("amqp.password")
+            zend_ini_string_literal("amqp.password")
         );
     }
 
@@ -452,7 +452,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
             Z_STRLEN_P(zdata)
         );
     } else {
-        zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("host"), INI_STR("amqp.host"));
+        zend_update_property_string(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("host"), zend_ini_string_literal("amqp.host"));
     }
 
     /* Pull the vhost out of the $params array */
@@ -485,11 +485,11 @@ static PHP_METHOD(amqp_connection_class, __construct)
             this_ce,
             PHP_AMQP_COMPAT_OBJ_P(getThis()),
             ZEND_STRL("vhost"),
-            INI_STR("amqp.vhost")
+            zend_ini_string_literal("amqp.vhost")
         );
     }
 
-    zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("port"), INI_INT("amqp.port"));
+    zend_update_property_long(this_ce, PHP_AMQP_COMPAT_OBJ_P(getThis()), ZEND_STRL("port"), zend_ini_long_literal("amqp.port"));
 
     if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), ZEND_STRL("port"))) != NULL) {
         SEPARATE_ZVAL(zdata);
@@ -513,7 +513,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("readTimeout"),
-        INI_FLT("amqp.read_timeout")
+        zend_ini_double_literal("amqp.read_timeout")
     );
 
     if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), ZEND_STRL("read_timeout"))) != NULL) {
@@ -566,19 +566,19 @@ static PHP_METHOD(amqp_connection_class, __construct)
     } else {
 
         assert(DEFAULT_TIMEOUT != NULL);
-        if (strcmp(DEFAULT_TIMEOUT, INI_STR("amqp.timeout")) != 0) {
+        if (strcmp(DEFAULT_TIMEOUT, zend_ini_string_literal("amqp.timeout")) != 0) {
             php_error_docref(
                 NULL,
                 E_DEPRECATED,
                 "INI setting 'amqp.timeout' is deprecated; use 'amqp.read_timeout' instead"
             );
 
-            if (strcmp(DEFAULT_READ_TIMEOUT, INI_STR("amqp.read_timeout")) == 0) {
+            if (strcmp(DEFAULT_READ_TIMEOUT, zend_ini_string_literal("amqp.read_timeout")) == 0) {
                 zend_update_property_double(
                     this_ce,
                     PHP_AMQP_COMPAT_OBJ_P(getThis()),
                     ZEND_STRL("readTimeout"),
-                    INI_FLT("amqp.timeout")
+                    zend_ini_double_literal("amqp.timeout")
                 );
             } else {
                 php_error_docref(
@@ -590,7 +590,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
                     this_ce,
                     PHP_AMQP_COMPAT_OBJ_P(getThis()),
                     ZEND_STRL("readTimeout"),
-                    INI_FLT("amqp.read_timeout")
+                    zend_ini_double_literal("amqp.read_timeout")
                 );
             }
         } else {
@@ -598,7 +598,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
                 this_ce,
                 PHP_AMQP_COMPAT_OBJ_P(getThis()),
                 ZEND_STRL("readTimeout"),
-                INI_FLT("amqp.read_timeout")
+                zend_ini_double_literal("amqp.read_timeout")
             );
         }
     }
@@ -607,7 +607,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("writeTimeout"),
-        INI_FLT("amqp.write_timeout")
+        zend_ini_double_literal("amqp.write_timeout")
     );
 
     if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), ZEND_STRL("write_timeout"))) != NULL) {
@@ -635,7 +635,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("rpcTimeout"),
-        INI_FLT("amqp.rpc_timeout")
+        zend_ini_double_literal("amqp.rpc_timeout")
     );
 
     if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), ZEND_STRL("rpc_timeout"))) != NULL) {
@@ -663,7 +663,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("connectTimeout"),
-        INI_FLT("amqp.connect_timeout")
+        zend_ini_double_literal("amqp.connect_timeout")
     );
 
     if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), ZEND_STRL("connect_timeout"))) != NULL) {
@@ -691,7 +691,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("channelMax"),
-        INI_INT("amqp.channel_max")
+        zend_ini_long_literal("amqp.channel_max")
     );
 
     if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), ZEND_STRL("channel_max"))) != NULL) {
@@ -724,7 +724,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("frameMax"),
-        INI_INT("amqp.frame_max")
+        zend_ini_long_literal("amqp.frame_max")
     );
 
     if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), ZEND_STRL("frame_max"))) != NULL) {
@@ -756,7 +756,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("heartbeat"),
-        INI_INT("amqp.heartbeat")
+        zend_ini_long_literal("amqp.heartbeat")
     );
 
     if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), ZEND_STRL("heartbeat"))) != NULL) {
@@ -774,7 +774,7 @@ static PHP_METHOD(amqp_connection_class, __construct)
         this_ce,
         PHP_AMQP_COMPAT_OBJ_P(getThis()),
         ZEND_STRL("saslMethod"),
-        INI_INT("amqp.sasl_method")
+        zend_ini_long_literal("amqp.sasl_method")
     );
 
     if (ini_arr && (zdata = zend_hash_str_find(HASH_OF(ini_arr), ZEND_STRL("sasl_method"))) != NULL) {
@@ -1999,7 +1999,7 @@ PHP_MINIT_FUNCTION(amqp_connection)
 
     memcpy(&amqp_connection_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
 
-    amqp_connection_object_handlers.offset = XtOffsetOf(amqp_connection_object, zo);
+    amqp_connection_object_handlers.offset = offsetof(amqp_connection_object, zo);
     amqp_connection_object_handlers.free_obj = amqp_connection_free;
 
     return SUCCESS;

--- a/amqp_queue.c
+++ b/amqp_queue.c
@@ -467,7 +467,7 @@ static PHP_METHOD(amqp_queue_class, get)
 
     zval message;
 
-    zend_long flags = INI_INT("amqp.auto_ack") ? AMQP_AUTOACK : AMQP_NOPARAM;
+    zend_long flags = zend_ini_long_literal("amqp.auto_ack") ? AMQP_AUTOACK : AMQP_NOPARAM;
     bool flags_is_null = 1;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l!", &flags, &flags_is_null) == FAILURE) {
@@ -559,7 +559,7 @@ static PHP_METHOD(amqp_queue_class, consume)
 
     char *consumer_tag = NULL;
     size_t consumer_tag_len = 0;
-    zend_long flags = INI_INT("amqp.auto_ack") ? AMQP_AUTOACK : AMQP_NOPARAM;
+    zend_long flags = zend_ini_long_literal("amqp.auto_ack") ? AMQP_AUTOACK : AMQP_NOPARAM;
     bool flags_is_null = 1;
 
     if (zend_parse_parameters(

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -84,9 +84,9 @@ extern zend_module_entry amqp_module_entry;
     #define zend_ini_parse_quantity_warn(v, name) (zend_atol(ZSTR_VAL(v), ZSTR_LEN(v)))
 #endif
 #if PHP_VERSION_ID < 80600
-    #define zend_ini_long_literal(name) zend_ini_long((name), sizeof("" name) - 1, false)
-    #define zend_ini_string_literal(name) zend_ini_string((name), sizeof("" name) - 1, false)
-    #define zend_ini_double_literal(name) zend_ini_double((name), sizeof("" name) - 1, false)
+    #define zend_ini_long_literal(name) zend_ini_long((name), sizeof("" name) - 1, 0)
+    #define zend_ini_string_literal(name) zend_ini_string((name), sizeof("" name) - 1, 0)
+    #define zend_ini_double_literal(name) zend_ini_double((name), sizeof("" name) - 1, 0)
 #endif
 #define PHP_AMQP_NULLABLE_DEFAULT_INIT(val, nullable)                                                                  \
     zval val;                                                                                                          \

--- a/php_amqp.h
+++ b/php_amqp.h
@@ -83,7 +83,11 @@ extern zend_module_entry amqp_module_entry;
 #if PHP_VERSION_ID < 80200
     #define zend_ini_parse_quantity_warn(v, name) (zend_atol(ZSTR_VAL(v), ZSTR_LEN(v)))
 #endif
-
+#if PHP_VERSION_ID < 80600
+    #define zend_ini_long_literal(name) zend_ini_long((name), sizeof("" name) - 1, false)
+    #define zend_ini_string_literal(name) zend_ini_string((name), sizeof("" name) - 1, false)
+    #define zend_ini_double_literal(name) zend_ini_double((name), sizeof("" name) - 1, false)
+#endif
 #define PHP_AMQP_NULLABLE_DEFAULT_INIT(val, nullable)                                                                  \
     zval val;                                                                                                          \
     if (nullable) {                                                                                                    \
@@ -305,12 +309,12 @@ struct _amqp_connection_object {
 
 static inline amqp_connection_object *php_amqp_connection_object_fetch(zend_object *obj)
 {
-    return (amqp_connection_object *) ((char *) obj - XtOffsetOf(amqp_connection_object, zo));
+    return (amqp_connection_object *) ((char *) obj - offsetof(amqp_connection_object, zo));
 }
 
 static inline amqp_channel_object *php_amqp_channel_object_fetch(zend_object *obj)
 {
-    return (amqp_channel_object *) ((char *) obj - XtOffsetOf(amqp_channel_object, zo));
+    return (amqp_channel_object *) ((char *) obj - offsetof(amqp_channel_object, zo));
 }
 
 #define PHP_AMQP_GET_CONNECTION(obj) php_amqp_connection_object_fetch(Z_OBJ_P(obj))


### PR DESCRIPTION
from UPGRADING.INTERNALS

  . The XtOffsetOf() alias of C’s offsetof() macro has been removed. Use
    offsetof() directly.

  . The INI_STR(), INI_INT(), INI_FLT(), and INI_BOOL() macros have been
    removed. Instead new zend_ini_{bool|long|double|str|string}_literal()
    macros have been added.

Also add the new macros for compatibility with old PHP versions